### PR TITLE
ENH: Add ``FullDKIModel''

### DIFF
--- a/src/eddymotion/estimator.py
+++ b/src/eddymotion/estimator.py
@@ -84,16 +84,20 @@ class EddyMotionEstimator:
             index_order = np.arange(len(dwdata))
             np.random.shuffle(index_order)
 
-            dwmodel = None
-            single_model = model.lower() in ("b0", "s0", "avg", "average", "mean")
-            if single_model:
-                # Factory creates the appropriate model and pipes arguments
-                dwmodel = ModelFactory.init(
-                    gtab=dwdata.gradients,
-                    model=model,
-                    n_jobs=n_jobs,
-                    **kwargs,
-                )
+            if model.lower().startswith("trivialdki"):
+                kwargs["data"] = dwdata.dataobj
+
+            single_model = (
+                model.lower() in ("b0", "s0", "avg", "average", "mean", "trivialdki")
+            )
+
+            # Factory creates the appropriate model and pipes arguments
+            dwmodel = ModelFactory.init(
+                gtab=dwdata.gradients,
+                model=model,
+                omp_nthreads=omp_nthreads,
+                **kwargs,
+            ) if single_model else None
 
             with TemporaryDirectory() as tmpdir:
                 print(f"Processing in <{tmpdir}>")

--- a/src/eddymotion/model.py
+++ b/src/eddymotion/model.py
@@ -203,7 +203,7 @@ class TrivialB0Model:
         return self._S0
 
 
-class TrivialDKIModel:
+class TrivialDKIModel(BaseModel):
     """
     A trivial model that returns a *b=0* map always.
 
@@ -219,6 +219,8 @@ class TrivialDKIModel:
     def __init__(self, gtab, data, S0=None, mask=None, b_max=4000, **kwargs):
         """Instantiate the wrapped tensor model."""
         from dipy.reconst.dki import DiffusionKurtosisModel
+
+        super().__init__()
 
         self._S0 = None
         if S0 is not None:
@@ -261,26 +263,10 @@ class TrivialDKIModel:
             # gtab = gtab[:, bval_mask]
 
         self._model = DiffusionKurtosisModel(_rasb2dipy(gtab), **kwargs)
-        self._model = self._model.fit(data[self._mask, ...])
+        super().fit(data, **kwargs)
 
     def fit(self, *args, **kwargs):
         """Do nothing."""
-
-    def predict(self, gradient, step=None, **kwargs):
-        """Propagate model parameters and call predict."""
-
-        predicted = np.squeeze(
-            self._model.predict(
-                _rasb2dipy(gradient),
-                S0=self._S0,
-            )
-        )
-        if predicted.ndim == 3:
-            return predicted
-
-        retval = np.zeros_like(self._mask, dtype="float32")
-        retval[self._mask, ...] = predicted
-        return retval
 
 
 class AverageDWModel:

--- a/src/eddymotion/model.py
+++ b/src/eddymotion/model.py
@@ -1,7 +1,7 @@
 """A factory class that adapts DIPY's dMRI models."""
 import warnings
 from joblib import Parallel, delayed
-
+import timeit
 import numpy as np
 from dipy.core.gradients import check_multi_b, gradient_table
 
@@ -44,8 +44,8 @@ class ModelFactory:
         if model.lower() in ("avg", "average", "mean"):
             return AverageDWModel(gtab=gtab, **kwargs)
 
-        if model.lower().startswith("trivialdki"):
-            return TrivialDKIModel(gtab, **kwargs)
+        if model.lower().startswith("fulldki"):
+            return FullDKIModel(gtab, **kwargs)
 
         # Generate a GradientTable object for DIPY
         gtab = _rasb2dipy(gtab)
@@ -90,6 +90,11 @@ class BaseModel:
     """
     Defines the interface and default methods.
 
+    Implements the interface of :obj:`dipy.reconst.base.ReconstModel`.
+    Instead of inheriting from the abstract base, this implementation
+    follows type adaptation principles, as it is easier to maintain
+    and to read (see https://www.youtube.com/watch?v=3MNVP9-hglc).
+
     """
 
     __slots__ = (
@@ -119,6 +124,9 @@ class BaseModel:
             else data.reshape(-1, data.shape[-1])
         )
 
+        # Get timestamp to evaluate performance
+        start_time = timeit.default_timer()
+
         # One single CPU - linear execution (full model)
         if n_jobs == 1:
             self._model, _ = _exec_fit(self._model, data)
@@ -137,6 +145,11 @@ class BaseModel:
             )
         for submodel, index in results:
             self._models[index] = submodel
+
+        print(
+            f"Multi-threaded ({n_jobs}) execution -- elapsed time "
+            f"{timeit.default_timer() - start_time} s."
+        )
 
         self._model = None  # Preempt further actions on the model
 
@@ -176,15 +189,7 @@ class BaseModel:
 
 
 class TrivialB0Model:
-    """
-    A trivial model that returns a *b=0* map always.
-
-    Implements the interface of :obj:`dipy.reconst.base.ReconstModel`.
-    Instead of inheriting from the abstract base, this implementation
-    follows type adaptation principles, as it is easier to maintain
-    and to read (see https://www.youtube.com/watch?v=3MNVP9-hglc).
-
-    """
+    """A trivial model that returns a *b=0* map always."""
 
     __slots__ = ("_S0",)
 
@@ -203,18 +208,16 @@ class TrivialB0Model:
         return self._S0
 
 
-class TrivialDKIModel(BaseModel):
+class FullDKIModel(BaseModel):
     """
-    A trivial model that returns a *b=0* map always.
+    A DKI model fitted on all data (i.e., no leave-out).
 
-    Implements the interface of :obj:`dipy.reconst.base.ReconstModel`.
-    Instead of inheriting from the abstract base, this implementation
-    follows type adaptation principles, as it is easier to maintain
-    and to read (see https://www.youtube.com/watch?v=3MNVP9-hglc).
+    In order to speed up optimization, this model fits DKI tensors only once using
+    the full dataset.
 
     """
 
-    __slots__ = ("_S0", "_mask", "_model")
+    __slots__ = ("_S0", "_mask", "_model", "_b_max")
 
     def __init__(self, gtab, data, S0=None, mask=None, b_max=4000, **kwargs):
         """Instantiate the wrapped tensor model."""
@@ -240,6 +243,8 @@ class TrivialDKIModel(BaseModel):
         if self._mask is not None:
             self._S0 = self._S0[self._mask.astype(bool)]
 
+        # Extract number of threads before we clean kwargs
+        n_jobs = kwargs.pop("n_jobs", None)
         kwargs = {
             k: v
             for k, v in kwargs.items()
@@ -253,6 +258,7 @@ class TrivialDKIModel(BaseModel):
                 "jac",
             )
         }
+        # kwargs["model_S0"] = None
 
         if b_max and b_max > 1000:
             # Saturate b-values at b_max, since signal stops dropping
@@ -261,12 +267,18 @@ class TrivialDKIModel(BaseModel):
             # bval_mask = gtab[-1] < b_max
             # data = data[..., bval_mask]
             # gtab = gtab[:, bval_mask]
+            self._b_max = b_max
 
         self._model = DiffusionKurtosisModel(_rasb2dipy(gtab), **kwargs)
-        super().fit(data, **kwargs)
+        super().fit(data, n_jobs=n_jobs, **kwargs)
 
     def fit(self, *args, **kwargs):
         """Do nothing."""
+
+    def predict(self, gradient, **kwargs):
+        """Ensure only acceptable arguments are passed."""
+        gradient[-1] = min(gradient[-1], self._b_max)
+        return super().predict(gradient)
 
 
 class AverageDWModel:
@@ -409,9 +421,7 @@ class DKIModel(BaseModel):
 
 
 class SparseFascicleModel(BaseModel):
-    """
-    A wrapper of :obj:`dipy.reconst.sfm.SparseFascicleModel`.
-    """
+    """A wrapper of :obj:`dipy.reconst.sfm.SparseFascicleModel`."""
 
     __slots__ = ("_solver", )
 

--- a/src/eddymotion/model.py
+++ b/src/eddymotion/model.py
@@ -252,15 +252,23 @@ class TrivialDKIModel:
             )
         }
 
+        if b_max and b_max > 1000:
+            # Saturate b-values at b_max, since signal stops dropping
+            gtab[-1, gtab[-1] > b_max] = b_max
+            # A possibly good alternative is completely remove very high b-values
+            # bval_mask = gtab[-1] < b_max
+            # data = data[..., bval_mask]
+            # gtab = gtab[:, bval_mask]
+
         self._model = DiffusionKurtosisModel(_rasb2dipy(gtab), **kwargs)
         self._model = self._model.fit(data[self._mask, ...])
-
 
     def fit(self, *args, **kwargs):
         """Do nothing."""
 
     def predict(self, gradient, step=None, **kwargs):
         """Propagate model parameters and call predict."""
+
         predicted = np.squeeze(
             self._model.predict(
                 _rasb2dipy(gradient),


### PR DESCRIPTION
The idea behind this model (credit goes to @tmspvn) is to only fit the DKI model once, which could be useful (and, importantly, way faster) for a first pass of head-motion correction.

This new model fits the DKI model at instantiation time, before entering the LOGO loop. Then, the ``predict()`` member just returns the map corresponding to the requested gradient (bvec/bval).

Therefore, it does some "double-dipping" in the sense that the gradient being predicted has already been "seen" in training. The model is likely degraded by the fact that the data are not aligned.

I will keep you updated (cc/ @yasseraleman).