### PR TITLE
FIX: Housekeeping of the data loader function

### DIFF
--- a/src/eddymotion/config/dwi-to-b0_level1.json
+++ b/src/eddymotion/config/dwi-to-b0_level1.json
@@ -28,7 +28,6 @@
     [ 0.01 ]
   ],
   "transforms": [ "Rigid", "Rigid" ],
-  "use_estimate_learning_rate_once": [ false, true ],
   "use_histogram_matching": [ true, true ],
   "verbose": true,
   "winsorize_lower_quantile": 0.0001,

--- a/src/eddymotion/config/dwi-to-dwi_level1.json
+++ b/src/eddymotion/config/dwi-to-dwi_level1.json
@@ -28,7 +28,6 @@
     [ 0.001 ]
   ],
   "transforms": [ "Rigid", "Affine" ],
-  "use_estimate_learning_rate_once": [ false, true ],
   "use_histogram_matching": [ true, true ],
   "verbose": true,
   "winsorize_lower_quantile": 0.0001,

--- a/src/eddymotion/dmri.py
+++ b/src/eddymotion/dmri.py
@@ -235,7 +235,7 @@ def load(
     if b0_file:
         b0img = nb.load(b0_file)
         retval.bzero = np.asanyarray(b0img.dataobj)
-    elif np.any(~gradmsk):
+    elif not np.all(gradmsk):
         retval.bzero = np.median(fulldata[..., ~gradmsk], axis=3)
 
     if brainmask_file:

--- a/src/eddymotion/dmri.py
+++ b/src/eddymotion/dmri.py
@@ -42,7 +42,10 @@ class DWI:
     """
     fieldmap = attr.ib(default=None, repr=_data_repr)
     """A 3D displacements field to unwarp susceptibility distortions."""
-    _filepath = attr.ib(factory=lambda: Path(mkdtemp()) / "em_cache.h5", repr=False,)
+    _filepath = attr.ib(
+        factory=lambda: Path(mkdtemp()) / "em_cache.h5",
+        repr=False,
+    )
     """A path to an HDF5 file to store the whole dataset."""
 
     def __len__(self):
@@ -88,11 +91,15 @@ class DWI:
 
         if with_b0:
             train_data = np.concatenate(
-                (np.asanyarray(self.bzero)[..., np.newaxis], train_data), axis=-1,
+                (np.asanyarray(self.bzero)[..., np.newaxis], train_data),
+                axis=-1,
             )
             b0vec = np.zeros((4, 1))
             b0vec[0, 0] = 1
-            train_gradients = np.concatenate((b0vec, train_gradients), axis=-1,)
+            train_gradients = np.concatenate(
+                (b0vec, train_gradients),
+                axis=-1,
+            )
 
         return (
             (train_data, train_gradients),
@@ -125,7 +132,8 @@ class DWI:
 
         # resample and update orientation at index
         self.dataobj[..., index] = np.asanyarray(
-            xform.apply(dwmoving, order=order).dataobj, dtype=self.dataobj.dtype,
+            xform.apply(dwmoving, order=order).dataobj,
+            dtype=self.dataobj.dtype,
         )
 
         # invert transform transform b-vector and origin

--- a/src/eddymotion/dmri.py
+++ b/src/eddymotion/dmri.py
@@ -167,13 +167,12 @@ class DWI:
 
     def to_nifti(self, filename, insert_b0=False):
         """Write a NIfTI 1.0 file to disk."""
-        data = self.dataobj if not insert_b0 else np.stack((
-            self.bzero[..., np.newaxis], self.dataobj,
-        ))
+        data = self.dataobj if not insert_b0 else np.concatenate((
+            self.bzero[..., np.newaxis], self.dataobj
+        ), axis=-1)
         nii = nb.Nifti1Image(data, self.affine, None)
         nii.header.set_xyzt_units("mm")
         nii.to_filename(filename)
-        return
 
     def plot_mosaic(self, index=None, **kwargs):
         """Visualize one direction of the dMRI dataset."""

--- a/test/test_dmri.py
+++ b/test/test_dmri.py
@@ -36,9 +36,9 @@ def test_load(datadir, tmp_path):
     bvecs_path = tmp_path / "dwi.bvecs"
     bvals_path = tmp_path / "dwi.bvals"
 
-    grad_table = np.vstack((np.zeros(4), dwi_h5.gradients))
+    grad_table = np.hstack((np.zeros((4, 1)), dwi_h5.gradients))
 
-    dwiobj.to_nifti(dwi_nifti_path, insert_b0=True)
+    dwi_h5.to_nifti(dwi_nifti_path, insert_b0=True)
     np.savetxt(str(gradients_path), grad_table.T)
     np.savetxt(str(bvecs_path), grad_table[:3])
     np.savetxt(str(bvals_path), grad_table[-1])


### PR DESCRIPTION
This PR revises the data loading:
- Add the possibility to read FSL's bvec/bval files for building the gradient table
- Remove reorientations of the data (still thinking why they were there in the first place)
- Calculating a b=0 map if none is provided