### PR TITLE
ENH: Outsource leave-one-out splitter so it can be used across data types

### DIFF
--- a/src/eddymotion/data/dmri.py
+++ b/src/eddymotion/data/dmri.py
@@ -39,6 +39,62 @@ def _data_repr(value):
     return f"<{'x'.join(str(v) for v in value.shape)} ({value.dtype})>"
 
 
+def logo_split(dwdata, index, with_b0=False):
+        """
+        Produce one fold of LOGO (leave-one-gradient-out).
+
+        Parameters
+        ----------
+        dwdata : :obj:`DWI`
+            DWI object
+        index : :obj:`int`
+            Index of the DWI orientation to be left out in this fold.
+        with_b0 : :obj:`bool`
+            Insert the *b=0* reference at the beginning of the training dataset.
+
+        Returns
+        -------
+        (train_data, train_gradients) : :obj:`tuple`
+            Training DWI and corresponding gradients.
+            Training data/gradients come **from the updated dataset**.
+        (test_data, test_gradients) :obj:`tuple`
+            Test 3D map (one DWI orientation) and corresponding b-vector/value.
+            The test data/gradient come **from the original dataset**.
+
+        """
+        if not Path(dwdata._filepath).exists():
+            dwdata.to_filename(dwdata._filepath)
+
+        # read original DWI data & b-vector
+        with h5py.File(dwdata._filepath, "r") as in_file:
+            root = in_file["/0"]
+            dwframe = np.asanyarray(root["dataobj"][..., index])
+            bframe = np.asanyarray(root["gradients"][..., index])
+
+        # if the size of the mask does not match data, cache is stale
+        mask = np.zeros(len(dwdata), dtype=bool)
+        mask[index] = True
+
+        train_data = dwdata.dataobj[..., ~mask]
+        train_gradients = dwdata.gradients[..., ~mask]
+
+        if with_b0:
+            train_data = np.concatenate(
+                (np.asanyarray(dwdata.bzero)[..., np.newaxis], train_data),
+                axis=-1,
+            )
+            b0vec = np.zeros((4, 1))
+            b0vec[0, 0] = 1
+            train_gradients = np.concatenate(
+                (b0vec, train_gradients),
+                axis=-1,
+            )
+
+        return (
+            (train_data, train_gradients),
+            (dwframe, bframe),
+        )
+
 @attr.s(slots=True)
 class DWI:
     """Data representation structure for dMRI data."""
@@ -73,60 +129,6 @@ class DWI:
     def __len__(self):
         """Obtain the number of high-*b* orientations."""
         return self.dataobj.shape[-1]
-
-    def logo_split(self, index, with_b0=False):
-        """
-        Produce one fold of LOGO (leave-one-gradient-out).
-
-        Parameters
-        ----------
-        index : :obj:`int`
-            Index of the DWI orientation to be left out in this fold.
-        with_b0 : :obj:`bool`
-            Insert the *b=0* reference at the beginning of the training dataset.
-
-        Returns
-        -------
-        (train_data, train_gradients) : :obj:`tuple`
-            Training DWI and corresponding gradients.
-            Training data/gradients come **from the updated dataset**.
-        (test_data, test_gradients) :obj:`tuple`
-            Test 3D map (one DWI orientation) and corresponding b-vector/value.
-            The test data/gradient come **from the original dataset**.
-
-        """
-        if not Path(self._filepath).exists():
-            self.to_filename(self._filepath)
-
-        # read original DWI data & b-vector
-        with h5py.File(self._filepath, "r") as in_file:
-            root = in_file["/0"]
-            dwframe = np.asanyarray(root["dataobj"][..., index])
-            bframe = np.asanyarray(root["gradients"][..., index])
-
-        # if the size of the mask does not match data, cache is stale
-        mask = np.zeros(len(self), dtype=bool)
-        mask[index] = True
-
-        train_data = self.dataobj[..., ~mask]
-        train_gradients = self.gradients[..., ~mask]
-
-        if with_b0:
-            train_data = np.concatenate(
-                (np.asanyarray(self.bzero)[..., np.newaxis], train_data),
-                axis=-1,
-            )
-            b0vec = np.zeros((4, 1))
-            b0vec[0, 0] = 1
-            train_gradients = np.concatenate(
-                (b0vec, train_gradients),
-                axis=-1,
-            )
-
-        return (
-            (train_data, train_gradients),
-            (dwframe, bframe),
-        )
 
     def set_transform(self, index, affine, order=3):
         """Set an affine, and update data object and gradients."""

--- a/src/eddymotion/data/dmri.py
+++ b/src/eddymotion/data/dmri.py
@@ -83,7 +83,7 @@ class DWI:
         with h5py.File(self._filepath, "r") as in_file:
             self._root = in_file["/0"]
 
-    def set_transform(self, dwframe, bvec, index, affine, order=3):
+    def set_transform(self, index, affine, order=3):
         """Set an affine, and update data object and gradients."""
         reference = namedtuple("ImageGrid", ("shape", "affine"))(
             shape=self.dataobj.shape[:3], affine=self.affine
@@ -95,6 +95,9 @@ class DWI:
             raise NotImplementedError
         else:
             xform = Affine(matrix=affine, reference=reference)
+
+        dwframe = np.asanyarray(self.dataobj[..., index])
+        bvec = np.asanyarray(self.gradients[:3, index])
 
         dwmoving = nb.Nifti1Image(dwframe, self.affine, None)
 

--- a/src/eddymotion/data/dmri.py
+++ b/src/eddymotion/data/dmri.py
@@ -70,6 +70,10 @@ class DWI:
     )
     """A path to an HDF5 file to store the whole dataset."""
 
+    def get_filename(self):
+        """Get the filepath of the HDF5 file."""
+        return self._filepath
+
     def __len__(self):
         """Obtain the number of high-*b* orientations."""
         return self.dataobj.shape[-1]

--- a/src/eddymotion/data/dmri.py
+++ b/src/eddymotion/data/dmri.py
@@ -122,7 +122,7 @@ class DWI:
     def __len__(self):
         """Obtain the number of high-*b* orientations."""
         return self.dataobj.shape[-1]
-    
+
     def set_data(self):
         # Generate dwframe and bframe
         if not Path(self._filepath).exists():
@@ -131,7 +131,7 @@ class DWI:
         # read original DWI data & b-vector
         with h5py.File(self._filepath, "r") as in_file:
             self._root = in_file["/0"]
-            
+
     def set_transform(self, dwframe, bvec, index, affine, order=3):
         """Set an affine, and update data object and gradients."""
         reference = namedtuple("ImageGrid", ("shape", "affine"))(

--- a/src/eddymotion/data/dmri.py
+++ b/src/eddymotion/data/dmri.py
@@ -62,14 +62,9 @@ def logo_split(dwdata, index, with_b0=False):
         The test data/gradient come **from the original dataset**.
 
     """
-    if not Path(dwdata._filepath).exists():
-        dwdata.to_filename(dwdata._filepath)
 
-    # read original DWI data & b-vector
-    with h5py.File(dwdata._filepath, "r") as in_file:
-        root = in_file["/0"]
-        dwframe = np.asanyarray(root["dataobj"][..., index])
-        bframe = np.asanyarray(root["gradients"][..., index])
+    dwframe = np.asanyarray(dwdata.root["dataobj"][..., index])
+    bframe = np.asanyarray(dwdata.root["gradients"][..., index])
 
     # if the size of the mask does not match data, cache is stale
     mask = np.zeros(len(dwdata), dtype=bool)
@@ -130,6 +125,15 @@ class DWI:
     def __len__(self):
         """Obtain the number of high-*b* orientations."""
         return self.dataobj.shape[-1]
+    
+    def set_data(self):
+        # Generate dwframe and bframe
+        if not Path(self._filepath).exists():
+            self.to_filename(self._filepath)
+            
+        # read original DWI data & b-vector
+        with h5py.File(self._filepath, "r") as in_file:
+            self.root = in_file["/0"]
 
     def set_transform(self, index, affine, order=3):
         """Set an affine, and update data object and gradients."""

--- a/src/eddymotion/data/dmri.py
+++ b/src/eddymotion/data/dmri.py
@@ -39,55 +39,6 @@ def _data_repr(value):
     return f"<{'x'.join(str(v) for v in value.shape)} ({value.dtype})>"
 
 
-def logo_split(dwdata, dwframe, bframe, index, with_b0=False):
-    """
-    Produce one fold of LOGO (leave-one-gradient-out).
-
-    Parameters
-    ----------
-    dwdata : :obj:`DWI`
-        DWI object
-    index : :obj:`int`
-        Index of the DWI orientation to be left out in this fold.
-    with_b0 : :obj:`bool`
-        Insert the *b=0* reference at the beginning of the training dataset.
-
-    Returns
-    -------
-    (train_data, train_gradients) : :obj:`tuple`
-        Training DWI and corresponding gradients.
-        Training data/gradients come **from the updated dataset**.
-    (test_data, test_gradients) :obj:`tuple`
-        Test 3D map (one DWI orientation) and corresponding b-vector/value.
-        The test data/gradient come **from the original dataset**.
-
-    """
-
-    # if the size of the mask does not match data, cache is stale
-    mask = np.zeros(len(dwdata), dtype=bool)
-    mask[index] = True
-
-    train_data = dwdata.dataobj[..., ~mask]
-    train_gradients = dwdata.gradients[..., ~mask]
-
-    if with_b0:
-        train_data = np.concatenate(
-            (np.asanyarray(dwdata.bzero)[..., np.newaxis], train_data),
-            axis=-1,
-        )
-        b0vec = np.zeros((4, 1))
-        b0vec[0, 0] = 1
-        train_gradients = np.concatenate(
-            (b0vec, train_gradients),
-            axis=-1,
-        )
-
-    return (
-        (train_data, train_gradients),
-        (dwframe, bframe),
-    )
-
-
 @attr.s(slots=True)
 class DWI:
     """Data representation structure for dMRI data."""

--- a/src/eddymotion/data/dmri.py
+++ b/src/eddymotion/data/dmri.py
@@ -74,15 +74,6 @@ class DWI:
         """Obtain the number of high-*b* orientations."""
         return self.dataobj.shape[-1]
 
-    def set_data(self):
-        # Generate dwframe and bframe
-        if not Path(self._filepath).exists():
-            self.to_filename(self._filepath)
-
-        # read original DWI data & b-vector
-        with h5py.File(self._filepath, "r") as in_file:
-            self._root = in_file["/0"]
-
     def set_transform(self, index, affine, order=3):
         """Set an affine, and update data object and gradients."""
         reference = namedtuple("ImageGrid", ("shape", "affine"))(
@@ -96,8 +87,14 @@ class DWI:
         else:
             xform = Affine(matrix=affine, reference=reference)
 
-        dwframe = np.asanyarray(self.dataobj[..., index])
-        bvec = np.asanyarray(self.gradients[:3, index])
+        if not Path(self._filepath).exists():
+            self.to_filename(self._filepath)
+
+        # read original DWI data & b-vector
+        with h5py.File(self._filepath, "r") as in_file:
+            root = in_file["/0"]
+            dwframe = np.asanyarray(root["dataobj"][..., index])
+            bvec = np.asanyarray(root["gradients"][:3, index])
 
         dwmoving = nb.Nifti1Image(dwframe, self.affine, None)
 

--- a/src/eddymotion/data/splitting.py
+++ b/src/eddymotion/data/splitting.py
@@ -53,7 +53,7 @@ def lovo_split(data, index):
     mask[index] = True
 
     train_data = data.dataobj[..., ~mask]
-    train_gradients = dwdata.gradients[..., ~mask]
+    train_gradients = data.gradients[..., ~mask]
 
     if with_b0:
         train_data = np.concatenate(

--- a/src/eddymotion/data/splitting.py
+++ b/src/eddymotion/data/splitting.py
@@ -62,8 +62,8 @@ def lovo_split(dataset, index, with_b0=False):
     mask[index] = True
 
     train_data = data[..., ~mask]
-    train_gradients = gradients[..., mask]
-    test_data = data[..., ~mask]
+    train_gradients = gradients[..., ~mask]
+    test_data = data[..., mask]
     test_gradients = gradients[..., mask]
 
     if with_b0:

--- a/src/eddymotion/data/splitting.py
+++ b/src/eddymotion/data/splitting.py
@@ -24,7 +24,7 @@
 import numpy as np
 
 
-def lovo_split(dwdata, dwframe, bframe, index, with_b0=False):
+def lovo_split(data, index):
     """
     Produce one fold of LOVO (leave-one-volume-out).
 

--- a/src/eddymotion/data/splitting.py
+++ b/src/eddymotion/data/splitting.py
@@ -51,15 +51,15 @@ def lovo_split(data, index, with_b0=False):
     if not Path(data.get_filename()).exists():
         data.to_filename(data.get_filename())
 
-    # if the size of the mask does not match data, cache is stale
-    mask = np.zeros(len(data), dtype=bool)
-    mask[index] = True
-
     # read original DWI data & b-vector
     with h5py.File(data.get_filename(), "r") as in_file:
         root = in_file["/0"]
-        dwframe = np.asanyarray(root["dataobj"][..., mask])
-        bframe = np.asanyarray(root["gradients"][..., mask])
+        dwframe = np.asanyarray(root["dataobj"][..., index])
+        bframe = np.asanyarray(root["gradients"][..., index])
+
+    # if the size of the mask does not match data, cache is stale
+    mask = np.zeros(len(data), dtype=bool)
+    mask[index] = True
 
     train_data = data.dataobj[..., ~mask]
     train_gradients = data.gradients[..., ~mask]

--- a/src/eddymotion/data/splitting.py
+++ b/src/eddymotion/data/splitting.py
@@ -30,7 +30,7 @@ def lovo_split(data, index):
 
     Parameters
     ----------
-    dwdata : :obj:`DWI`
+    data : :obj:`eddymotion.data.dmri.DWI`
         DWI object
     index : :obj:`int`
         Index of the DWI orientation to be left out in this fold.

--- a/src/eddymotion/data/splitting.py
+++ b/src/eddymotion/data/splitting.py
@@ -69,5 +69,5 @@ def lovo_split(data, index):
 
     return (
         (train_data, train_gradients),
-        (dwframe, bframe),
+        (data.dataobj[..., mask], data.gradients[..., mask]),
     )

--- a/src/eddymotion/data/splitting.py
+++ b/src/eddymotion/data/splitting.py
@@ -49,7 +49,7 @@ def lovo_split(dataset, index, with_b0=False):
     """
 
     if not Path(dataset.get_filename()).exists():
-        dataset.to_filename(data.get_filename())
+        dataset.to_filename(dataset.get_filename())
 
     # read original DWI data & b-vector
     with h5py.File(dataset.get_filename(), "r") as in_file:

--- a/src/eddymotion/data/splitting.py
+++ b/src/eddymotion/data/splitting.py
@@ -53,18 +53,6 @@ def lovo_split(data, index):
     train_data = data.dataobj[..., ~mask]
     train_gradients = data.gradients[..., ~mask]
 
-    if with_b0:
-        train_data = np.concatenate(
-            (np.asanyarray(dwdata.bzero)[..., np.newaxis], train_data),
-            axis=-1,
-        )
-        b0vec = np.zeros((4, 1))
-        b0vec[0, 0] = 1
-        train_gradients = np.concatenate(
-            (b0vec, train_gradients),
-            axis=-1,
-        )
-
     return (
         (train_data, train_gradients),
         (data.dataobj[..., mask], data.gradients[..., mask]),

--- a/src/eddymotion/data/splitting.py
+++ b/src/eddymotion/data/splitting.py
@@ -34,8 +34,6 @@ def lovo_split(data, index):
         DWI object
     index : :obj:`int`
         Index of the DWI orientation to be left out in this fold.
-    with_b0 : :obj:`bool`
-        Insert the *b=0* reference at the beginning of the training dataset.
 
     Returns
     -------

--- a/src/eddymotion/data/splitting.py
+++ b/src/eddymotion/data/splitting.py
@@ -26,13 +26,13 @@ import numpy as np
 import h5py
 
 
-def lovo_split(data, index, with_b0=False):
+def lovo_split(dataset, index, with_b0=False):
     """
     Produce one fold of LOVO (leave-one-volume-out).
 
     Parameters
     ----------
-    data : :obj:`eddymotion.data.dmri.DWI`
+    dataset : :obj:`eddymotion.data.dmri.DWI`
         DWI object
     index : :obj:`int`
         Index of the DWI orientation to be left out in this fold.
@@ -48,25 +48,25 @@ def lovo_split(data, index, with_b0=False):
 
     """
 
-    if not Path(data.get_filename()).exists():
-        data.to_filename(data.get_filename())
+    if not Path(dataset.get_filename()).exists():
+        dataset.to_filename(data.get_filename())
 
     # read original DWI data & b-vector
-    with h5py.File(data.get_filename(), "r") as in_file:
+    with h5py.File(dataset.get_filename(), "r") as in_file:
         root = in_file["/0"]
-        dwframe = np.asanyarray(root["dataobj"][..., index])
-        bframe = np.asanyarray(root["gradients"][..., index])
+        data = np.asanyarray(root["dataobj"])
+        gradients = np.asanyarray(root["gradients"])
 
     # if the size of the mask does not match data, cache is stale
-    mask = np.zeros(len(data), dtype=bool)
+    mask = np.zeros(data.shape[-1], dtype=bool)
     mask[index] = True
 
-    train_data = data.dataobj[..., ~mask]
-    train_gradients = data.gradients[..., ~mask]
+    train_data = data[..., ~mask]
+    train_gradients = gradients[..., ~mask]
 
     if with_b0:
         train_data = np.concatenate(
-            (np.asanyarray(data.bzero)[..., np.newaxis], train_data),
+            (np.asanyarray(dataset.bzero)[..., np.newaxis], train_data),
             axis=-1,
         )
         b0vec = np.zeros((4, 1))

--- a/src/eddymotion/data/splitting.py
+++ b/src/eddymotion/data/splitting.py
@@ -1,0 +1,73 @@
+# emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
+# vi: set ft=python sts=4 ts=4 sw=4 et:
+#
+# Copyright 2022 The NiPreps Developers <nipreps@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We support and encourage derived works from this project, please read
+# about our expectations at
+#
+#     https://www.nipreps.org/community/licensing/
+#
+"""Data splitting helpers."""
+import numpy as np
+
+
+def lovo_split(dwdata, dwframe, bframe, index, with_b0=False):
+    """
+    Produce one fold of LOVO (leave-one-volume-out).
+
+    Parameters
+    ----------
+    dwdata : :obj:`DWI`
+        DWI object
+    index : :obj:`int`
+        Index of the DWI orientation to be left out in this fold.
+    with_b0 : :obj:`bool`
+        Insert the *b=0* reference at the beginning of the training dataset.
+
+    Returns
+    -------
+    (train_data, train_gradients) : :obj:`tuple`
+        Training DWI and corresponding gradients.
+        Training data/gradients come **from the updated dataset**.
+    (test_data, test_gradients) :obj:`tuple`
+        Test 3D map (one DWI orientation) and corresponding b-vector/value.
+        The test data/gradient come **from the original dataset**.
+
+    """
+
+    # if the size of the mask does not match data, cache is stale
+    mask = np.zeros(len(dwdata), dtype=bool)
+    mask[index] = True
+
+    train_data = dwdata.dataobj[..., ~mask]
+    train_gradients = dwdata.gradients[..., ~mask]
+
+    if with_b0:
+        train_data = np.concatenate(
+            (np.asanyarray(dwdata.bzero)[..., np.newaxis], train_data),
+            axis=-1,
+        )
+        b0vec = np.zeros((4, 1))
+        b0vec[0, 0] = 1
+        train_gradients = np.concatenate(
+            (b0vec, train_gradients),
+            axis=-1,
+        )
+
+    return (
+        (train_data, train_gradients),
+        (dwframe, bframe),
+    )

--- a/src/eddymotion/data/splitting.py
+++ b/src/eddymotion/data/splitting.py
@@ -62,7 +62,9 @@ def lovo_split(dataset, index, with_b0=False):
     mask[index] = True
 
     train_data = data[..., ~mask]
-    train_gradients = gradients[..., ~mask]
+    train_gradients = gradients[..., mask]
+    test_data = data[..., ~mask]
+    test_gradients = gradients[..., mask]
 
     if with_b0:
         train_data = np.concatenate(
@@ -78,5 +80,5 @@ def lovo_split(dataset, index, with_b0=False):
 
     return (
         (train_data, train_gradients),
-        (dwframe, bframe),
+        (test_data, test_gradients),
     )

--- a/src/eddymotion/data/splitting.py
+++ b/src/eddymotion/data/splitting.py
@@ -47,7 +47,7 @@ def lovo_split(data, index):
     """
 
     # if the size of the mask does not match data, cache is stale
-    mask = np.zeros(len(dwdata), dtype=bool)
+    mask = np.zeros(len(data), dtype=bool)
     mask[index] = True
 
     train_data = data.dataobj[..., ~mask]

--- a/src/eddymotion/data/splitting.py
+++ b/src/eddymotion/data/splitting.py
@@ -52,7 +52,7 @@ def lovo_split(data, index):
     mask = np.zeros(len(dwdata), dtype=bool)
     mask[index] = True
 
-    train_data = dwdata.dataobj[..., ~mask]
+    train_data = data.dataobj[..., ~mask]
     train_gradients = dwdata.gradients[..., ~mask]
 
     if with_b0:

--- a/src/eddymotion/estimator.py
+++ b/src/eddymotion/estimator.py
@@ -152,6 +152,8 @@ class EddyMotionEstimator:
                             f"Pass {i_iter + 1}/{n_iter} | Fit and predict b-index <{i}>"
                         )
                         data_train, data_test = logo_split(dwdata, i)
+                        grad_str = f"{i}, {data_test[1][:3]}, b={int(data_test[1][3])}"
+                        pbar.set_description_str(f"[{grad_str}], {n_jobs} jobs")
 
                         if not single_model:  # A true LOGO estimator
                             if hasattr(dwdata, "gradients"):

--- a/src/eddymotion/estimator.py
+++ b/src/eddymotion/estimator.py
@@ -34,6 +34,7 @@ from pkg_resources import resource_filename as pkg_fn
 from tqdm import tqdm
 
 from eddymotion.model import ModelFactory
+from eddymotion.dmri import logo_split
 
 
 class EddyMotionEstimator:
@@ -150,7 +151,7 @@ class EddyMotionEstimator:
                         pbar.set_description_str(
                             f"Pass {i_iter + 1}/{n_iter} | Fit and predict b-index <{i}>"
                         )
-                        data_train, data_test = dwdata.logo_split(i, with_b0=True)
+                        data_train, data_test = logo_split(dwdata, i, with_b0=True)
                         grad_str = f"{i}, {data_test[1][:3]}, b={int(data_test[1][3])}"
                         pbar.set_description_str(f"[{grad_str}], {n_jobs} jobs")
 

--- a/src/eddymotion/estimator.py
+++ b/src/eddymotion/estimator.py
@@ -153,9 +153,6 @@ class EddyMotionEstimator:
                         )
                         data_train, data_test = logo_split(dwdata, i)
 
-                        grad_str = f"{i}, {data_test[1][:3]}, b={int(data_test[1][3])}"
-                        pbar.set_description_str(f"[{grad_str}], {n_jobs} jobs")
-
                         if not single_model:  # A true LOGO estimator
                             if hasattr(dwdata, "gradients"):
                                 kwargs["gtab"] = data_train[1]

--- a/src/eddymotion/estimator.py
+++ b/src/eddymotion/estimator.py
@@ -94,6 +94,8 @@ class EddyMotionEstimator:
         if "num_threads" not in align_kwargs and omp_nthreads is not None:
             align_kwargs["num_threads"] = omp_nthreads
 
+        orig = dwdata
+
         n_iter = len(models)
         for i_iter, model in enumerate(models):
             reg_target_type = (
@@ -152,7 +154,12 @@ class EddyMotionEstimator:
                         pbar.set_description_str(
                             f"Pass {i_iter + 1}/{n_iter} | Fit and predict b-index <{i}>"
                         )
-                        data_train, data_test = logo_split(dwdata, i, with_b0=True)
+                        dwframe = np.asanyarray(orig.dataobj[..., i])
+                        bframe = np.asanyarray(orig.gradients[..., i])
+                        data_train, data_test = logo_split(
+                            dwdata, dwframe, bframe, i, with_b0=True
+                        )
+
                         grad_str = f"{i}, {data_test[1][:3]}, b={int(data_test[1][3])}"
                         pbar.set_description_str(f"[{grad_str}], {n_jobs} jobs")
 

--- a/src/eddymotion/estimator.py
+++ b/src/eddymotion/estimator.py
@@ -35,6 +35,7 @@ from tqdm import tqdm
 
 from eddymotion.dmri import logo_split
 from eddymotion.model import ModelFactory
+from eddymotion.dmri import logo_split
 
 
 class EddyMotionEstimator:

--- a/src/eddymotion/estimator.py
+++ b/src/eddymotion/estimator.py
@@ -33,8 +33,8 @@ from nitransforms.linear import Affine
 from pkg_resources import resource_filename as pkg_fn
 from tqdm import tqdm
 
-from eddymotion.model import ModelFactory
 from eddymotion.dmri import logo_split
+from eddymotion.model import ModelFactory
 
 
 class EddyMotionEstimator:

--- a/src/eddymotion/estimator.py
+++ b/src/eddymotion/estimator.py
@@ -33,7 +33,7 @@ from nitransforms.linear import Affine
 from pkg_resources import resource_filename as pkg_fn
 from tqdm import tqdm
 
-from eddymotion.data.splitting import lovo_split as logo_split
+from eddymotion.data.splitting import lovo_split
 from eddymotion.model import ModelFactory
 
 
@@ -151,7 +151,7 @@ class EddyMotionEstimator:
                         pbar.set_description_str(
                             f"Pass {i_iter + 1}/{n_iter} | Fit and predict b-index <{i}>"
                         )
-                        data_train, data_test = logo_split(dwdata, i)
+                        data_train, data_test = lovo_split(dwdata, i)
                         grad_str = f"{i}, {data_test[1][:3]}, b={int(data_test[1][3])}"
                         pbar.set_description_str(f"[{grad_str}], {n_jobs} jobs")
 

--- a/src/eddymotion/estimator.py
+++ b/src/eddymotion/estimator.py
@@ -33,7 +33,7 @@ from nitransforms.linear import Affine
 from pkg_resources import resource_filename as pkg_fn
 from tqdm import tqdm
 
-from eddymotion.dmri import logo_split
+from eddymotion.data.splitting import lovo_split as logo_split
 from eddymotion.model import ModelFactory
 
 

--- a/src/eddymotion/estimator.py
+++ b/src/eddymotion/estimator.py
@@ -151,7 +151,7 @@ class EddyMotionEstimator:
                         pbar.set_description_str(
                             f"Pass {i_iter + 1}/{n_iter} | Fit and predict b-index <{i}>"
                         )
-                        data_train, data_test = lovo_split(dwdata, i)
+                        data_train, data_test = lovo_split(dwdata, i, with_b0=True)
                         grad_str = f"{i}, {data_test[1][:3]}, b={int(data_test[1][3])}"
                         pbar.set_description_str(f"[{grad_str}], {n_jobs} jobs")
 

--- a/src/eddymotion/estimator.py
+++ b/src/eddymotion/estimator.py
@@ -93,8 +93,6 @@ class EddyMotionEstimator:
         if "num_threads" not in align_kwargs and omp_nthreads is not None:
             align_kwargs["num_threads"] = omp_nthreads
 
-        orig = dwdata
-
         n_iter = len(models)
         for i_iter, model in enumerate(models):
             reg_target_type = (
@@ -153,8 +151,8 @@ class EddyMotionEstimator:
                         pbar.set_description_str(
                             f"Pass {i_iter + 1}/{n_iter} | Fit and predict b-index <{i}>"
                         )
-                        dwframe = np.asanyarray(orig.dataobj[..., i])
-                        bframe = np.asanyarray(orig.gradients[..., i])
+                        dwframe = np.asanyarray(dwdata.dataobj[..., i])
+                        bframe = np.asanyarray(dwdata.gradients[..., i])
                         data_train, data_test = logo_split(
                             dwdata, dwframe, bframe, i, with_b0=True
                         )

--- a/src/eddymotion/estimator.py
+++ b/src/eddymotion/estimator.py
@@ -35,7 +35,6 @@ from tqdm import tqdm
 
 from eddymotion.dmri import logo_split
 from eddymotion.model import ModelFactory
-from eddymotion.dmri import logo_split
 
 
 class EddyMotionEstimator:

--- a/src/eddymotion/estimator.py
+++ b/src/eddymotion/estimator.py
@@ -223,6 +223,7 @@ class EddyMotionEstimator:
                                     matrix=dwdata.em_affines[i], reference=reference
                                 )
                             mat_file = tmp_dir / f"init_{i_iter}_{i:05d}.mat"
+
                             initial_xform.to_filename(mat_file, fmt="itk")
                             registration.inputs.initial_moving_transform = str(mat_file)
 

--- a/src/eddymotion/estimator.py
+++ b/src/eddymotion/estimator.py
@@ -214,7 +214,6 @@ class EddyMotionEstimator:
                                     matrix=dwdata.em_affines[i], reference=reference
                                 )
                             mat_file = tmp_dir / f"init_{i_iter}_{i:05d}.mat"
-
                             initial_xform.to_filename(mat_file, fmt="itk")
                             registration.inputs.initial_moving_transform = str(mat_file)
 

--- a/src/eddymotion/estimator.py
+++ b/src/eddymotion/estimator.py
@@ -151,11 +151,7 @@ class EddyMotionEstimator:
                         pbar.set_description_str(
                             f"Pass {i_iter + 1}/{n_iter} | Fit and predict b-index <{i}>"
                         )
-                        dwframe = np.asanyarray(dwdata.dataobj[..., i])
-                        bframe = np.asanyarray(dwdata.gradients[..., i])
-                        data_train, data_test = logo_split(
-                            dwdata, dwframe, bframe, i, with_b0=True
-                        )
+                        data_train, data_test = logo_split(dwdata, i)
 
                         grad_str = f"{i}, {data_test[1][:3]}, b={int(data_test[1][3])}"
                         pbar.set_description_str(f"[{grad_str}], {n_jobs} jobs")

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -25,6 +25,7 @@ import numpy as np
 import pytest
 
 from eddymotion import model
+from eddymotion.data.splitting import lovo_split
 from eddymotion.data.dmri import DWI
 
 
@@ -94,7 +95,7 @@ def test_two_initialisations(datadir):
     dmri_dataset = DWI.from_filename(datadir / "dwi.h5")
 
     # Split data into test and train set
-    data_train, data_test = dmri_dataset.logo_split(10)
+    data_train, data_test = lovo_split(dmri_dataset, 10)
 
     # Direct initialisation
     model1 = model.AverageDWModel(

--- a/test/test_splitting.py
+++ b/test/test_splitting.py
@@ -1,0 +1,63 @@
+# emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
+# vi: set ft=python sts=4 ts=4 sw=4 et:
+#
+# Copyright 2021 The NiPreps Developers <nipreps@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We support and encourage derived works from this project, please read
+# about our expectations at
+#
+#     https://www.nipreps.org/community/licensing/
+#
+"""Unit test testing the lovo_split function."""
+import pytest
+import numpy as np
+from eddymotion.data.dmri import DWI
+from eddymotion.data.splitting import lovo_split
+
+
+def test_lovo_split(datadir):
+    """
+    Test the lovo_split function.
+
+    Parameters:
+    - datadir: The directory containing the test data.
+
+    Returns:
+    None
+    """
+    data = DWI.from_filename(datadir / "dwi.h5")
+
+    # Set zeros in dataobj and gradients of the dwi object
+    data.dataobj[:] = 0
+    data.gradients[:] = 0
+
+    # Select a random index
+    index = np.random.randint(len(data))
+
+    # Set 1 in dataobj and gradients of the dwi object at this specific index
+    data.dataobj[..., index] = 1
+    data.gradients[..., index] = 1
+
+    # Apply the lovo_split function at the specified index
+    (train_data, train_gradients), \
+        (test_data, test_gradients) = lovo_split(data, index)
+
+    # Check if the test data contains only 1s
+    # and the train data contains only 0s after the split
+    assert np.all(test_data == 1)
+    assert np.all(train_data == 0)
+    assert np.all(test_gradients == 1)
+    assert np.all(train_gradients == 0)
+

--- a/test/test_splitting.py
+++ b/test/test_splitting.py
@@ -21,7 +21,6 @@
 #     https://www.nipreps.org/community/licensing/
 #
 """Unit test testing the lovo_split function."""
-import pytest
 import numpy as np
 from eddymotion.data.dmri import DWI
 from eddymotion.data.splitting import lovo_split


### PR DESCRIPTION
(Empty message edited by @oesteban)

This PR covers two targets:

- [x] Extract the "logo" splitter from the `DWI` object. The rationale behind this is allowing its use across different data types (e.g., with PET).
- [x] Incidentally, change the name from "logo" (for leave-one-gradient-out) to "lovo" (for leave-one-volume-out).