### PR TITLE
MAINT: Pin Python >= 3.8

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: ["3.8", "3.9", "3.10"]
         pip: ["pip==21.2", "pip~=22.0"]
 
     steps:

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,9 +7,10 @@ classifiers =
     Intended Audience :: Science/Research
     Topic :: Scientific/Engineering :: Image Recognition
     License :: OSI Approved :: Apache Software License
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
 description = Pure python eddy-current and head-motion correction for dMRI, an extension of QSIprep's SHOREline algorithm (Cieslak, 2020) to multiple diffusion models.
 license = Apache License, Version 2.0
 long_description = file:README.rst
@@ -19,7 +20,7 @@ maintainer_email = nipreps@gmail.com, dpysalexander@gmail.com
 url = https://github.com/nipreps/eddymotion
 
 [options]
-python_requires = >=3.7
+python_requires = >=3.8
 setup_requires =
     setuptools >= 45
     setuptools_scm >= 6.2


### PR DESCRIPTION
Although Python 3.7 end-of-life is set for in 6 months (Jun 27, 2023), scikit-learn does not support it as of 1.8.0 (which will become the minimal version with #161).

I belive discontinuing Python 3.7 at this point is better than implementing the bspline matrix ourselves.