### PR TITLE
MAINT: Rotate CircleCI secrets and setup up org-level context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,6 +90,8 @@ workflows:
   build_test_deploy:
     jobs:
       - tests:
+          context:
+            - nipreps-common
           filters:
             branches:
               ignore:
@@ -106,4 +108,6 @@ workflows:
               only:
                 - main
     jobs:
-      - tests
+      - tests:
+          context:
+            - nipreps-common


### PR DESCRIPTION
Responding to CircleCI's security alert on Jan 4, 2023 this PR rotates the secrets of this project.