### PR TITLE
ENH: Add newer Python versions to package testing

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         pip: ["pip==21.2", "pip~=22.0"]
 
     steps:


### PR DESCRIPTION
Add newer Python versions to package testing: add Python 3.11 and Python 3.12.