### PR TITLE
ENH: Fix GitHub workflow actions warnings linked to `Node.js`

### DIFF
--- a/.github/workflows/docs-build-update.yml
+++ b/.github/workflows/docs-build-update.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         ssh-key: "${{ secrets.NIPREPS_DEPLOY }}"
         fetch-depth: 0


### PR DESCRIPTION
Fix GitHub workflow actions warnings linked to `Node.js`: bump
`actions/checkout`.

Fixes:
```
Node.js 16 actions are deprecated.
Please update the following actions to use Node.js 20:
actions/checkout@v2. For more information see:
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```

and
```
The following actions uses node12 which is deprecated and will be forced to run on node16:
actions/checkout@v2. For more info:
https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
```

raised for example in:
https://github.com/nipreps/eddymotion/actions/runs/8375229804
