### PR TITLE
ENH: Remove unused parameter from method prototype

### DIFF
--- a/src/eddymotion/data/dmri.py
+++ b/src/eddymotion/data/dmri.py
@@ -195,8 +195,9 @@ class DWI:
                         compression_opts=compression_opts,
                     )
 
-    def to_nifti(self, filename, insert_b0=False):
+    def to_nifti(self, filename, **kwargs):
         """Write a NIfTI 1.0 file to disk."""
+        insert_b0 = kwargs.get("insert_b0", False)
         data = (
             self.dataobj
             if not insert_b0

--- a/src/eddymotion/data/pet.py
+++ b/src/eddymotion/data/pet.py
@@ -121,7 +121,7 @@ class PET:
                         compression_opts=compression_opts,
                     )
 
-    def to_nifti(self, filename, insert_b0=False):
+    def to_nifti(self, filename, *_):
         """Write a NIfTI 1.0 file to disk."""
         nii = nb.Nifti1Image(self.dataobj, self.affine, None)
         nii.header.set_xyzt_units("mm")


### PR DESCRIPTION
Remove unused parameter from method prototype: PET images do not have a `b0` image. Use the `*_` to denote unused arguments for the `PET` class and use a `kwargs` dictionary for the `DWI` case.