### PR TITLE
ENH: Remove unnecessary `docs/requirements.txt`

### DIFF
--- a/.github/workflows/docs-build-pr.yml
+++ b/.github/workflows/docs-build-pr.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install -U build hatch pip
-        pip install -r docs/requirements.txt
+        pip install .[doc]
         python -m hatch version | tail -n1
 
     - name: Build docs

--- a/.github/workflows/docs-build-update.yml
+++ b/.github/workflows/docs-build-update.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install -U build hatch pip
-        pip install -r docs/requirements.txt
+        pip install .[doc]
         python -m hatch version | tail -n1
 
     - name: Build docs

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,0 @@
-attrs >= 20.1.0
-furo >= 2024.01.29
-matplotlib >= 2.2.0
-packaging
-sphinx >= 4.5
-sphinxcontrib-apidoc
-nireports


### PR DESCRIPTION
Remove unnecessary `docs/requirements.txt`: documentation dependencies are listed in the `[doc]` section of the `pyproject.toml` file.

Use the `pip install .[doc]` command to install the package dependencies, including the documentation packages, in the GitHub workflow files.