### PR TITLE
ENH: Use NumPy's `Generator` class as a replacement for `RandomState`

### DIFF
--- a/src/eddymotion/estimator.py
+++ b/src/eddymotion/estimator.py
@@ -75,8 +75,9 @@ class EddyMotionEstimator:
             Number of parallel jobs.
         seed : :obj:`int` or :obj:`bool`
             Seed the random number generator (necessary when we want deterministic
-            estimation).
-
+            estimation). If an integer, the value is used to initialize the
+            generator; if ``True``, the arbitrary value of ``20210324`` is used
+            to initialize it.
         Return
         ------
         affines : :obj:`list` of :obj:`numpy.ndarray`
@@ -86,8 +87,11 @@ class EddyMotionEstimator:
         """
         align_kwargs = align_kwargs or {}
 
+        _seed = None
         if seed or seed == 0:
-            np.random.seed(20210324 if seed is True else seed)
+            _seed = 20210324 if seed is True else seed
+
+        rng = np.random.default_rng(_seed)
 
         if "num_threads" not in align_kwargs and omp_nthreads is not None:
             align_kwargs["num_threads"] = omp_nthreads
@@ -120,7 +124,7 @@ class EddyMotionEstimator:
                 kwargs["xlim"] = dwdata.total_duration
 
             index_order = np.arange(len(dwdata))
-            np.random.shuffle(index_order)
+            rng.shuffle(index_order)
 
             single_model = model.lower() in (
                 "b0",


### PR DESCRIPTION
Use NumPy's `Generator` class as a replacement for `RandomState` for random variarte generation methods.

`RandomState` was deprecated in NumPy 1.17.0.

Take advantage of the commit to document better the use of the `seed` parameter.

Documentation:
https://numpy.org/doc/stable/reference/random/new-or-different.html#what-s-new-or-different
https://numpy.org/doc/stable/reference/random/generated/numpy.random.seed.html
