### PR TITLE
ENH: Add Python 3.12 to project classifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 license = "Apache-2.0"
 requires-python = ">=3.8"


### PR DESCRIPTION
Add Python 3.12 to project classifiers. Python 3.12 was introduced in commit d27a448.