### PR TITLE
ENH: Refactor code linter and formatter dependencies

### DIFF
--- a/.github/workflows/contrib.yml
+++ b/.github/workflows/contrib.yml
@@ -20,4 +20,4 @@ jobs:
         with:
           python-version: 3
       - name: Lint EddyMotion
-        run: pipx run ruff check
+        run: pipx run ruff check --diff

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,15 +10,9 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: debug-statements
-  - repo: https://github.com/timothycrosley/isort
-    rev: 5.10.1
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.3.4
     hooks:
-      - id: isort
-  - repo: https://github.com/psf/black
-    rev: 22.3.0
-    hooks:
-      - id: black
-  - repo: https://github.com/pycqa/flake8
-    rev: 4.0.1
-    hooks:
-      - id: flake8
+      - id: ruff
+        args: [ --fix ]
+      - id: ruff-format

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,8 +6,10 @@ full list see the documentation:
 http://www.sphinx-doc.org/en/master/config
 
 """
+
 from packaging.version import Version
-from eddymotion import __version__, __copyright__, __packagename__
+
+from eddymotion import __copyright__, __packagename__, __version__
 
 # -- Path setup --------------------------------------------------------------
 # If extensions (or modules to document with autodoc) are in another directory,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,10 +57,7 @@ doc = [
 ]
 
 dev = [
-    "black",
-    "flake8",
-    "flake8-pyproject",
-    "isort",
+    "ruff",
     "pre-commit",
     "pre-commit-hooks",
 ]
@@ -113,32 +110,21 @@ version-file = "src/eddymotion/_version.py"
 # Developer tool configurations
 #
 
-[tool.black]
-line-length = 99
-target-version = ['py39']
-skip-string-normalization = true
-exclude = '''
-# Directories
-/(
-    \.eggs
-  | \.git
-  | \.hg
-  | \.mypy_cache
-  | \.tox
-  | \.venv
-  | venv
-  | _build
-  | build
-  | dist
-)/
-'''
-
-[tool.isort]
-profile = 'black'
-skip_gitignore = true
-
 [tool.ruff]
 line-length = 99
+target-version = "py39"
+exclude = [
+  ".eggs",
+  ".git",
+  ".hg",
+  ".mypy_cache",
+  ".tox",
+  ".venv",
+  "venv",
+  "_build",
+  "build",
+  "dist",
+]
 
 [tool.ruff.lint]
 select = [
@@ -147,6 +133,7 @@ select = [
   "C",
   "W",
   "B",
+  "I",
 ]
 ignore = [
   "E203"
@@ -163,6 +150,9 @@ inline-quotes = "double"
 
 [tool.ruff.format]
 quote-style = "double"
+
+[tool.ruff.lint.isort]
+known-first-party=["eddymotion"]
 
 [tool.pytest.ini_options]
 pythonpath = "src/ test/"

--- a/test/test_dmri.py
+++ b/test/test_dmri.py
@@ -21,8 +21,10 @@
 #     https://www.nipreps.org/community/licensing/
 #
 """Unit tests exercising the dMRI data structure."""
-import pytest
+
 import numpy as np
+import pytest
+
 from eddymotion.data.dmri import load
 
 
@@ -54,7 +56,11 @@ def test_load(datadir, tmp_path):
     assert np.allclose(dwi_h5.gradients, dwi_from_nifti1.gradients)
 
     # Try loading NIfTI + b-vecs/vals
-    dwi_from_nifti2 = load(dwi_nifti_path, bvec_file=bvecs_path, bval_file=bvals_path,)
+    dwi_from_nifti2 = load(
+        dwi_nifti_path,
+        bvec_file=bvecs_path,
+        bval_file=bvals_path,
+    )
 
     assert np.allclose(dwi_h5.dataobj, dwi_from_nifti2.dataobj)
     assert np.allclose(dwi_h5.bzero, dwi_from_nifti2.bzero)


### PR DESCRIPTION
Refactor code linter and formatter dependencies:
- Remove `black`, `flake8` and `isort` dependencies from `pyproject.toml`: the role has been taken over by `ruff` in commit 81b3690.
- Transfer the `black` and `isort` rules left behind to `ruff` in `pyproject.toml`
- Remove `black`, `flake8` and `isort` from the pre-commit config file and use `ruff` instead.