### PR TITLE
ENH: Simplify `eddymotion.estimator.EddyMotionEstimator.fit`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,7 +146,6 @@ inline-quotes = "double"
 "*/__init__.py" = ["F401"]
 "docs/conf.py" = ["E265"]
 "/^\\s*\\.\\. _.*?: http/" = ["E501"]
-"src/eddymotion/estimator.py" = ["C901"]
 
 [tool.ruff.format]
 quote-style = "double"


### PR DESCRIPTION
Simplify `eddymotion.estimator.EddyMotionEstimator.fit`: break down different parts into separate methods.

Fixes:
```
src/eddymotion/estimator.py:43:9: C901 `fit` is too complex (23 > 10)
```

raised by `ruff`.

Remove the `C901` error exception rule from the `ruff` linter whitelist.

Fixes #142.