### PR TITLE
ENH: Drop support for Python 3.8 and 3.9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
           paths:
             - /tmp/ants
 
-      - run: 
+      - run:
           name: Configure git (pacify datalad)
           command: |
             git config --global user.name "First Last"
@@ -55,7 +55,7 @@ jobs:
             - data-v1-{{ .Branch }}-
             - data-v1-main-
             - data-v1-
-      - run: 
+      - run:
           name: Pull down test data
           command: |
             if [[ ! -d "${TEST_DATA_HOME}" ]]; then

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4
@@ -39,7 +39,7 @@ jobs:
         python -m venv /tmp/buildenv
         source /tmp/buildenv/bin/activate
         pip install -U build hatch pip twine
-        
+
         python -m build -s -w
         python -m twine check dist/eddymotion-*
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,14 +13,12 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "Topic :: Scientific/Engineering :: Image Recognition",
     "License :: OSI Approved :: Apache Software License",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
 ]
 license = "Apache-2.0"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 dependencies = [
     "dipy>=1.3.0",
     "joblib",
@@ -112,7 +110,7 @@ version-file = "src/eddymotion/_version.py"
 
 [tool.ruff]
 line-length = 99
-target-version = "py39"
+target-version = "py310"
 exclude = [
   ".eggs",
   ".git",


### PR DESCRIPTION
Drop support for Python 3.8 and 3.9: require Python 3.10 or greater in line with Scientific Python SPEC 0:
https://scientific-python.org/specs/spec-0000/

Remove them from the CI matrices.

Use CircleCI's docker image so that the pacakge gets tested on Python 3.10:
https://hub.docker.com/u/cimg

Resolves #140.