### PR TITLE
ENH: Require the iterables in a `zip` call to have equal length

### DIFF
--- a/.maint/paper_author_list.py
+++ b/.maint/paper_author_list.py
@@ -57,7 +57,7 @@ if __name__ == "__main__":
         % "; ".join(
             [
                 "%s \\ :sup:`%s`\\ " % (i["name"], idx)
-                for i, idx in zip(author_matches, aff_indexes)
+                for i, idx in zip(author_matches, aff_indexes, strict=True)
             ]
         )
     )


### PR DESCRIPTION
Require the iterables in a `zip` call to have equal length.

Fixes:
```
installing ruff...
--- .maint/paper_author_list.py
+++ .maint/paper_author_list.py
@@ -57,7 +57,7 @@
         % "; ".join(
             [
                 "%s \\ :sup:`%s`\\ " % (i["name"], idx)
-                for i, idx in zip(author_matches, aff_indexes)
+                for i, idx in zip(author_matches, aff_indexes, strict=False)
             ]
         )
     )

Would fix 1 error.
```

raised for example in:
https://github.com/nipreps/eddymotion/actions/runs/8674793170/job/23787520437?pr=158#step:4:26

Documentation:
https://docs.astral.sh/ruff/rules/zip-without-explicit-strict/#zip-without-explicit-strict-b905