### PR TITLE
DOC: Remove unnamed return parameter from docstring

### DIFF
--- a/src/eddymotion/estimator.py
+++ b/src/eddymotion/estimator.py
@@ -80,7 +80,7 @@ class EddyMotionEstimator:
             estimation). See :func:`_sort_dwdata_indices`.
         Return
         ------
-        affines : :obj:`list` of :obj:`numpy.ndarray`
+        :obj:`list` of :obj:`numpy.ndarray`
             A list of :math:`4 \times 4` affine matrices encoding the estimated
             parameters of the deformations caused by head-motion and eddy-currents.
 


### PR DESCRIPTION
Remove unnamed return parameter from `EddyMotionEstimator` class docstring.