### PR TITLE
ENH: Require Sphinx greater or equal 7.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ doc = [
     "packaging",
     "pydot >= 1.2.3",
     "pydotplus",
-    "sphinx >= 4.5",
+    "sphinx >= 7.2",
     "sphinx-argparse",
     "sphinx_rtd_theme",
     "sphinxcontrib-apidoc ~= 0.3.0",


### PR DESCRIPTION
Require Sphinx greater or equal 7.2 (released Aug 16, 2023).

Fixes:
```
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed.
This behaviour is the source of the following dependency conflicts.
sphinx 4.5.0 requires docutils<0.18,>=0.14, but you have docutils 0.21.1 which is incompatible.
sphinx-rtd-theme 1.0.0 requires docutils<0.18, but you have docutils 0.21.1 which is incompatible.
```

raised for example in:
https://app.circleci.com/pipelines/github/nipreps/eddymotion/978/workflows/62e30eb5-72ed-4cf9-8b47-0172cad51228/jobs/951