### PR TITLE
ENH: Require the iterables in a zip call to have equal length

### DIFF
--- a/.maint/update_authors.py
+++ b/.maint/update_authors.py
@@ -49,7 +49,7 @@ def read_md_table(md_text):
             break
 
         values = [v.strip() or None for v in line.split("|")][1:-1]
-        retval.append({k: v for k, v in zip(keys, values) if v})
+        retval.append({k: v for k, v in zip(keys, values, strict=True) if v})
 
     return retval
 
@@ -288,7 +288,12 @@ def publication(
     print("Authors (%d):" % len(hits))
     print(
         "%s."
-        % "; ".join(["%s \\ :sup:`%s`\\ " % (i["name"], idx) for i, idx in zip(hits, aff_indexes)])
+        % "; ".join(
+            [
+                "%s \\ :sup:`%s`\\ " % (i["name"], idx)
+                for i, idx in zip(hits, aff_indexes, strict=True)
+            ]
+        )
     )
 
     print(


### PR DESCRIPTION
Require the iterables in a `zip` call to have equal length.

Fixes:
```
installing ruff...
--- .maint/update_authors.py
+++ .maint/update_authors.py
@@ -49,7 +49,7 @@
             break

         values = [v.strip() or None for v in line.split("|")][1:-1]
-        retval.append({k: v for k, v in zip(keys, values) if v})
+        retval.append({k: v for k, v in zip(keys, values, strict=False) if v})

     return retval

@@ -288,7 +288,7 @@
     print("Authors (%d):" % len(hits))
     print(
         "%s."
-        % "; ".join(["%s \\ :sup:`%s`\\ " % (i["name"], idx) for i, idx in zip(hits, aff_indexes)])
+        % "; ".join(["%s \\ :sup:`%s`\\ " % (i["name"], idx) for i, idx in zip(hits, aff_indexes, strict=False)])
     )

     print(

Would fix 2 errors.
```

raised for example in:
https://github.com/nipreps/eddymotion/actions/runs/8707149384/job/23881469441?pr=169#step:4:36

Documentation:
https://docs.astral.sh/ruff/rules/zip-without-explicit-strict/#zip-without-explicit-strict-b905