### PR TITLE
ENH: Bump CircleCI docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 jobs:
   tests:
     docker: # executor type
-      - image: nipreps/miniconda:py39_2205.0
+      - image: nipreps/miniconda:py39_2403.0
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PAT


### PR DESCRIPTION
Bump CircleCI docker image.

Fixes:
```
ERROR: Package 'eddymotion' requires a different Python: 3.9.12 not in '>=3.10'
```

raised for example in:
https://app.circleci.com/pipelines/github/nipreps/eddymotion/978/workflows/62e30eb5-72ed-4cf9-8b47-0172cad51228/jobs/951