### PR TITLE
DOC: Fix `ModelNotFitterError` class docstring

### DIFF
--- a/src/eddymotion/exceptions.py
+++ b/src/eddymotion/exceptions.py
@@ -24,7 +24,7 @@
 
 class ModelNotFittedError(ValueError, AttributeError):
     """
-    Exception class to raise if estimator is used before fitting.
+    Exception class to raise if a model is used before fitting.
 
     This class inherits from both ValueError and AttributeError to help with
     exception handling.


### PR DESCRIPTION
Fix `ModelNotFitterError` class docstring to honor its purpose.