### PR TITLE
MAINT: Revision of GHA migration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,7 @@ defaults:
 env:
   FORCE_COLOR: true
   TEST_DATA_HOME: /home/runner/eddymotion-tests/
+  ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS: 4
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Tests
+name: Unit and integration tests
 
 on:
   push:
@@ -19,6 +19,7 @@ defaults:
 # Force tox and pytest to use color
 env:
   FORCE_COLOR: true
+  TEST_DATA_HOME: /home/runner/eddymotion-tests/
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -28,41 +29,54 @@ permissions:
   contents: read
 
 jobs:
-  stable:
-    # Check each OS, all supported Python, minimum versions and latest releases
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: ['ubuntu-latest']
-        python-version: ['3.10', '3.11', '3.12']
-        dependencies: ['full', 'pre']
-        include:
-          - os: ubuntu-latest
-            python-version: '3.10'
-            dependencies: 'min'
-
-    env:
-      DEPENDS: ${{ matrix.dependencies }}
+  test:
+    runs-on: 'ubuntu-latest'
 
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
           fetch-depth: 0
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+
+      - uses: mamba-org/setup-micromamba@v1.9.0
         with:
-          python-version: ${{ matrix.python-version }}
-          allow-prereleases: true
-      - name: Display Python version
-        run: python -c "import sys; print(sys.version)"
-      - name: Install tox
+          environment-file: env.yml
+          init-shell: bash
+          cache-environment: true
+          cache-environment-key: environment-v1
+          cache-downloads: false
+          post-cleanup: 'none'
+          generate-run-shell: true
+          # https://github.com/mamba-org/setup-micromamba/issues/225
+          micromamba-version: 1.5.10-0
+          micromamba-binary-path: /home/runner/micromamba-bin-versioned/micromamba
+
+      - uses: actions/cache/restore@v4
+        with:
+          path: /home/runner/eddymotion-tests/
+          key: data-v0
+
+      - name: Get test data with DataLad
+        shell: micromamba-shell {0}
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install tox tox-gh-actions
+          if [[ ! -d "${TEST_DATA_HOME}" ]]; then
+            datalad install -rg --source=https://gin.g-node.org/nipreps-data/tests-eddymotion.git ${TEST_DATA_HOME}
+          else
+            cd ${TEST_DATA_HOME}
+            datalad update --merge -r .
+            datalad get -r -J4 *
+          fi
+
+      - uses: actions/cache/save@v4
+        with:
+          path: /home/runner/eddymotion-tests/
+          key: data-v0
+
       - name: Show tox config
+        shell: micromamba-shell {0}
         run: tox c
       - name: Run tox
+        shell: micromamba-shell {0}
         run: tox -v --exit-and-dump-after 1200
       - uses: codecov/codecov-action@v4
         if: ${{ always() }}

--- a/env.yml
+++ b/env.yml
@@ -1,0 +1,28 @@
+name: eddymotion
+channels:
+  - conda-forge
+# Update this ~yearly; last updated Jan 2024
+dependencies:
+  - python=3.12
+  # Intel Math Kernel Library for numpy
+  - mkl=2023.2.0
+  - mkl-service=2.4.0
+  # git-annex for templateflow users with DataLad superdatasets
+  - git-annex=*=alldep*
+  # Workflow dependencies: ANTs
+  - ants=2.5
+  - pip
+  - pip:
+    - datalad
+    - dipy>=1.3.0
+    - h5py
+    - joblib
+    - tox
+    - tox-gh-actions
+    - coverage
+    - pytest
+    - pytest-cov
+    - pytest-env
+    - pytest-xdist
+variables:
+  FSLOUTPUTTYPE: NIFTI_GZ

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -23,10 +23,10 @@
 """Integration tests."""
 
 import os
+
 import nibabel as nb
 import nitransforms as nt
 import numpy as np
-
 import pytest
 
 from eddymotion.data.dmri import DWI

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -22,14 +22,18 @@
 #
 """Integration tests."""
 
+import os
 import nibabel as nb
 import nitransforms as nt
 import numpy as np
+
+import pytest
 
 from eddymotion.data.dmri import DWI
 from eddymotion.estimator import EddyMotionEstimator
 
 
+@pytest.mark.skipif(os.getenv("GITHUB_ACTIONS", "false") == "true", reason="Skip GHA")
 def test_proximity_estimator_trivial_model(datadir):
     """Check the proximity of transforms estimated by the estimator with a trivial B0 model."""
 

--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,12 @@ pass_env =
   NO_COLOR
   CLICOLOR
   CLICOLOR_FORCE
+  GITHUB_ACTIONS
+  TEST_DATA_HOME
+  TEST_OUTPUT_DIR
+  TEST_WORK_DIR
+  PYTHONHASHSEED
+  ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS
 extras = test
 commands =
   pytest --doctest-modules --cov eddymotion -n auto -x --cov-report xml \

--- a/tox.ini
+++ b/tox.ini
@@ -2,28 +2,17 @@
 requires =
   tox>=4
 envlist =
-  py3{10,11,12}-{full,pre}
-  py310-min
+  py312
 skip_missing_interpreters = true
 
 # Configuration that allows us to split tests across GitHub runners effectively
 [gh-actions]
 python =
-  3.10: py310
-  3.11: py311
   3.12: py312
-
-[gh-actions:env]
-DEPENDS =
-  min: min
-  full: full
-  pre: pre
 
 [testenv]
 description = Pytest with coverage
 labels = test
-pip_pre =
-  pre: true
 pass_env =
   # getpass.getuser() sources for Windows:
   LOGNAME
@@ -37,11 +26,8 @@ pass_env =
   CLICOLOR
   CLICOLOR_FORCE
 extras = test
-deps =
-  min: nipype ==1.8.5
-  min: pybids ==0.15.6
 commands =
-  pytest --doctest-modules --cov eddymotion --cov-report xml \
+  pytest --doctest-modules --cov eddymotion -n auto -x --cov-report xml \
   --junitxml=test-results.xml -v src test {posargs}
 
 [testenv:docs]

--- a/tox.ini
+++ b/tox.ini
@@ -42,7 +42,7 @@ deps =
   min: pybids ==0.15.6
 commands =
   pytest --doctest-modules --cov eddymotion --cov-report xml \
-  --junitxml=test-results.xml -v src/eddymotion {posargs}
+  --junitxml=test-results.xml -v src test {posargs}
 
 [testenv:docs]
 description = Build documentation site


### PR DESCRIPTION
Revises the GHA migration to make sure that tests run:

- Added dataset download using datalad (as it was the case in Circle)
- Improved the tox config to ensure environment variables are considered
- Added execution of pytest on the `test/` folder.
- Does not test on a matrix of pythons because the python version should not introduce differences (to consider when we have code where it could be a problem).

IMHO, the addition of tox deviates from other projects (and as far as I understand, we were not planning on using tox) and has introduced some complexity. In particular, I had to set one test to skip because of (I suspect) some minimal environment change tox introduces.

For now, I wanted to focus on the download of data and execution of all tests. Future PRs can address the removal of tox if we finally decide against it.