### PR TITLE
MAINT: Adopt `tox` for testing environment configuration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,7 @@ env:
   FORCE_COLOR: true
   TEST_DATA_HOME: /home/runner/eddymotion-tests/
   ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS: 4
+  ANTSPATH: /usr/share/miniconda/bin/
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -30,35 +31,48 @@ permissions:
   contents: read
 
 jobs:
-  test:
-    runs-on: 'ubuntu-latest'
+  stable:
+    # Check each OS, all supported Python, minimum versions and latest releases
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: ['ubuntu-latest']
+        python-version: ['3.10', '3.11', '3.12']
+        dependencies: ['full', 'pre']
+        include:
+          - os: ubuntu-latest
+            python-version: '3.10'
+            dependencies: 'min'
+
+    env:
+      DEPENDS: ${{ matrix.dependencies }}
 
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
           fetch-depth: 0
-
-      - uses: mamba-org/setup-micromamba@v1.9.0
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
         with:
-          environment-file: env.yml
-          init-shell: bash
-          cache-environment: true
-          cache-environment-key: environment-v1
-          cache-downloads: false
-          post-cleanup: 'none'
-          generate-run-shell: true
-          # https://github.com/mamba-org/setup-micromamba/issues/225
-          micromamba-version: 1.5.10-0
-          micromamba-binary-path: /home/runner/micromamba-bin-versioned/micromamba
-
+          python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
+      - name: Display Python version
+        run: python -c "import sys; print(sys.version)"
+      - name: Install ANTs
+        run: |
+          conda install conda-forge::ants
+      - name: Install datalad
+        run: |
+          python -m pip install datalad-installer
+          datalad-installer --sudo ok git-annex
+          python -m pip install datalad datalad-osf
+          datalad wtf
       - uses: actions/cache/restore@v4
         with:
           path: /home/runner/eddymotion-tests/
           key: data-v0
-
       - name: Get test data with DataLad
-        shell: micromamba-shell {0}
         run: |
           if [[ ! -d "${TEST_DATA_HOME}" ]]; then
             datalad install -rg --source=https://gin.g-node.org/nipreps-data/tests-eddymotion.git ${TEST_DATA_HOME}
@@ -67,22 +81,20 @@ jobs:
             datalad update --merge -r .
             datalad get -r -J4 *
           fi
-
       - uses: actions/cache/save@v4
         with:
           path: /home/runner/eddymotion-tests/
           key: data-v0
-
-      - name: Install editable
-        shell: micromamba-shell {0}
+      - name: Install tox
         run: |
-          pip install -e .
-
-      - name: Run tests
-        shell: micromamba-shell {0}
+          python -m pip install --upgrade pip
+          python -m pip install tox tox-gh-actions
+      - name: Show tox config
+        run: tox c
+      - name: Run tox
         run: |
-          pytest --doctest-modules --cov eddymotion -n auto -x --cov-report xml \
-                 --junitxml=test-results.xml -v src test
+          export PATH=$ANTSPATH:$PATH
+          tox -v --exit-and-dump-after 1200
       - uses: codecov/codecov-action@v4
         if: ${{ always() }}
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ requires-python = ">=3.10"
 dependencies = [
     "dipy>=1.3.0",
     "joblib",
-    "nipype>= 1.5.1, < 2.0",
+    "nipype>= 1.5.1,<2.0",
     "nitransforms>=21.0.0,<24",
     "nireports",
     "numpy>=1.17.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "dipy>=1.3.0",
     "joblib",
     "nipype>= 1.5.1, < 2.0",
-    "nitransforms>=21.0.0",
+    "nitransforms>=21.0.0,<24",
     "nireports",
     "numpy>=1.17.3",
     "nest-asyncio>=1.5.1",

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,78 @@
+[tox]
+requires =
+  tox>=4
+envlist =
+  py312
+skip_missing_interpreters = true
+
+# Configuration that allows us to split tests across GitHub runners effectively
+[gh-actions]
+python =
+  3.12: py312
+
+[testenv]
+description = Pytest with coverage
+labels = test
+pass_env =
+  # getpass.getuser() sources for Windows:
+  LOGNAME
+  USER
+  LNAME
+  USERNAME
+  # Pass user color preferences through
+  PY_COLORS
+  FORCE_COLOR
+  NO_COLOR
+  CLICOLOR
+  CLICOLOR_FORCE
+  GITHUB_ACTIONS
+  TEST_DATA_HOME
+  TEST_OUTPUT_DIR
+  TEST_WORK_DIR
+  PYTHONHASHSEED
+  ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS
+  PATH
+extras = test
+commands =
+  pytest --doctest-modules --cov eddymotion -n auto --cov-report xml \
+  --junitxml=test-results.xml -v src test {posargs}
+
+[testenv:docs]
+description = Build documentation site
+labels = docs
+allowlist_externals = make
+extras = doc
+commands =
+  make -C doc html
+
+[testenv:spellcheck]
+description = Check spelling
+labels = check
+deps =
+  codespell[toml]
+skip_install = true
+commands =
+  codespell . {posargs}
+
+[testenv:build{,-strict}]
+labels =
+  check
+  pre-release
+deps =
+  build
+  twine
+skip_install = true
+set_env =
+  build-strict: PYTHONWARNINGS=error
+commands =
+  python -m build
+  python -m twine check dist/*
+
+[testenv:publish]
+depends = build
+labels = release
+deps =
+  twine
+skip_install = true
+commands =
+  python -m twine upload dist/*


### PR DESCRIPTION
Adopt `tox` for testing environment configuration as per decision at the Oct 1 2024 Technical Monitoring meeting.

Add the necessary `tox.ini` file and edit the GHA `test.yml` workflow file to use `tox`, to use `ants`, to use `DataLad` to download the testing data, and to cache the data across the build matrix.

Pin `nitransforms` to <24 following commit d26541b. The decision on pinning to <24 was made following consistent failures on `test_proximity_estimator_trivial_model`, e.g.
https://github.com/nipreps/eddymotion/actions/runs/11123784605/job/30907972182#step:8:196
and
https://github.com/nipreps/eddymotion/actions/runs/11203922080/job/31141711676?pr=234#step:12:342

The version was pinned for the conda `env.yml` config file, but not `pyproject.toml`.