### PR TITLE
DOC: Fix cut passages from `README` in documentation index file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,8 +47,12 @@ More recently, Cieslak et al. [#r3]_ integrated both approaches in *SHORELine*, 
 the work of ``eddy`` and *SHORELine*, while generalizing these methods to multiple acquisition schemes
 (single-shell, multi-shell, and diffusion spectrum imaging) using diffusion models available with DIPY [#r5]_.
 
+.. BEGIN FLOWCHART
+
 .. image:: https://raw.githubusercontent.com/nipreps/eddymotion/507fc9bab86696d5330fd6a86c3870968243aea8/docs/_static/eddymotion-flowchart.svg
    :alt: The eddymotion flowchart
+
+.. END FLOWCHART
 
 .. [#r1] S. Ben-Amitay et al., Motion correction and registration of high b-value diffusion weighted images, Magnetic
    Resonance in Medicine 67:1694–1702 (2012)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,9 +1,8 @@
 .. include:: links.rst
 .. include:: ../README.rst
-   :end-line: 29
+   :end-before: BEGIN FLOWCHART
 .. include:: ../README.rst
-   :start-line: 34
-
+   :start-after: END FLOWCHART
 
 .. image:: _static/eddymotion-flowchart.svg
    :alt: The eddymotion flowchart


### PR DESCRIPTION
Fix cut passages from `README` in documentation index file: add comments around the flowchart image in the `README` file and change the `start-line` and `end-line` directive pair for the `end-before` and `start-after` pair to skip the flowchart image only.

The `start-line` and `end-line` directives were making such that relevant passages of the `README` file providing context for the tool were not being included. Thus the text shown in the documentation index file had some missing parts, and was not making sense.