### PR TITLE
STYLE: Make Kriging hyperparameter property naming consistent

### DIFF
--- a/src/eddymotion/model/gpr.py
+++ b/src/eddymotion/model/gpr.py
@@ -288,7 +288,7 @@ class ExponentialKriging(Kernel):
         return Hyperparameter("beta_a", "numeric", self.a_bounds)
 
     @property
-    def hyperparameter_beta_l(self) -> Hyperparameter:
+    def hyperparameter_l(self) -> Hyperparameter:
         return Hyperparameter("beta_l", "numeric", self.l_bounds)
 
     def __call__(
@@ -394,7 +394,7 @@ class SphericalKriging(Kernel):
         return Hyperparameter("beta_a", "numeric", self.a_bounds)
 
     @property
-    def hyperparameter_beta_l(self) -> Hyperparameter:
+    def hyperparameter_l(self) -> Hyperparameter:
         return Hyperparameter("beta_l", "numeric", self.l_bounds)
 
     def __call__(


### PR DESCRIPTION
Make Kriging hyperparameter property naming consistent: use `hyperparameter_l` instead of `hyperparameter_beta_l` for the `beta_l` hyperparameter, much like `hyperparameter_a` is being used for the `beta_a` hyperparameter.