### PR TITLE
DOC: Add `__init__` documentation to class documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -234,6 +234,11 @@ apidoc_excluded_paths = ["conftest.py", "*/tests/*", "tests/*", "config/*"]
 apidoc_separate_modules = True
 apidoc_extra_args = ["--module-first", "-d 1", "-T"]
 
+
+# -- Options for autodoc extension -------------------------------------------
+autoclass_content = "both"
+
+
 # -- Options for intersphinx extension ---------------------------------------
 
 # Example configuration for intersphinx: refer to the Python standard library.
@@ -253,3 +258,25 @@ intersphinx_mapping = {
 
 # -- Options for versioning extension ----------------------------------------
 scv_show_banner = True
+
+
+# -- Special functions -------------------------------------------------------
+import inspect
+
+
+def autodoc_process_signature(app, what, name, obj, options, signature, return_annotation):
+    """Replace the class signature by the signature from cls.__init__"""
+
+    if what == "class" and hasattr(obj, "__init__"):
+        try:
+            init_signature = inspect.signature(obj.__init__)
+            # Convert the Signature object to a string
+            return str(init_signature), return_annotation
+        except ValueError:
+            # Handle cases where `inspect.signature` fails
+            return signature, return_annotation
+    return signature, return_annotation
+
+
+def setup(app):
+    app.connect("autodoc-process-signature", autodoc_process_signature)

--- a/src/eddymotion/model/gpr.py
+++ b/src/eddymotion/model/gpr.py
@@ -264,7 +264,6 @@ class ExponentialKriging(Kernel):
         l_bounds: tuple[float, float] = BOUNDS_LAMBDA,
     ):
         r"""
-        Initialize an exponential Kriging kernel.
 
         Parameters
         ----------
@@ -370,7 +369,6 @@ class SphericalKriging(Kernel):
         l_bounds: tuple[float, float] = BOUNDS_LAMBDA,
     ):
         r"""
-        Initialize a spherical Kriging kernel.
 
         Parameters
         ----------


### PR DESCRIPTION
Add `__init__` documentation to class documentation:
- Add a function to the documentation configuration file that processes the signatures and adds the `__init__` method signature to the class signatures.
- Make the class documentation contain the documentation from both the class and the `__ini__` method setting the `autoclass_content` option to `both`.

Remove the short description of the `__init__` methods so that the class documentation reads seamlessly.