### PR TITLE
DOC: Fix installation documentation Python version

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -5,7 +5,7 @@ Installation
 ============
 Make sure all of *eddymotion*' `External Dependencies`_ are installed.
 
-On a functional Python 3.7 (or above) environment with ``pip`` installed,
+On a functional Python 3.10 (or above) environment with ``pip`` installed,
 *eddymotion* can be installed using the habitual command ::
 
     $ python -m pip install eddymotion


### PR DESCRIPTION
Fix installation documentation Python version: the tool supports Python greater than or equal to 3.10.